### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const { randomUUID } = require("crypto");
 const fs = require("fs");
 
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const http = require("http");
 const SocketIO = require("socket.io");
 
@@ -12,6 +13,13 @@ const https = require("https")
 
 const port = 8180;
 let authorized = {};
+
+// Rate limiter for auth route
+const authLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // limit each IP to 10 requests per windowMs
+  message: "Too many authentication attempts from this IP, please try again after a minute"
+});
 
 let config = {
 	delay: 30000
@@ -66,7 +74,7 @@ const nextSlide = function() {
 nextSlide();
 
 // oauth2
-app.get("/auth", async function(req, res) {
+app.get("/auth", authLimiter, async function(req, res) {
 	const authorizationUri = oauth2.authorizeURL({
 	  redirect_uri: `${process.env.BASE_URL}/authed`,
 	  scope: 'user/basic user/names',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "express": "^4.21.2",
     "https-post": "0.1.1",
     "simple-oauth2": "^5.0.0",
-    "socket.io": "^4.7.2"
+    "socket.io": "^4.7.2",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@types/simple-oauth2": "^5.0.7"


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/Infobord/security/code-scanning/2](https://github.com/djoamersfoort/Infobord/security/code-scanning/2)

To mitigate this vulnerability, we should add rate limiting middleware specifically to the `/auth` endpoint (and optionally `/authed` if it poses similar risks, but CodeQL only flagged `/auth`). The express-rate-limit package is a well-known and maintained middleware for Express. 

Steps to implement:
- Import the `express-rate-limit` package in `index.js`.
- Define a rate limiter configuration specific to the `/auth` route. For example, allow a modest number of attempts per minute (e.g., 10 per minute).
- Add the rate limiter as middleware to the `/auth` route, i.e., pass it as the first argument in `app.get('/auth', limiter, ...)`.

Only the code in `index.js` needs modification, and no existing functionality will be affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
